### PR TITLE
add filter for Rollbar JS config

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -180,14 +180,19 @@ class Plugin {
         if ($this->settings['client_side_access_token'] == '')
             return;
         
+
+        $rollbarJsConfig = array(
+          'accessToken' => $this->settings['client_side_access_token'],
+          'captureUncaught' => true,
+          'payload' => array(
+            'environment' => $this->settings['environment']
+          ),
+        );
+
+        $rollbarJsConfig = apply_filters('rollbar_js_config', $rollbarJsConfig);
+        
         $rollbarJs = \Rollbar\RollbarJsHelper::buildJs(
-            array(
-                'accessToken' => $this->settings['client_side_access_token'],
-                "captureUncaught" => true,
-                "payload" => array(
-                    'environment' => $this->settings['environment']
-                ),
-            )
+          $rollbarJsConfig
         );
         
         echo $rollbarJs;


### PR DESCRIPTION
Allows a plugin to modify the JS config passed to Rollbar.

You can use this e.g. to add the currently logged in user to the "person" field
of the payload. With this change, you could have this plugin:

```
class RollbarWPUser {
  public function __construct(){
    add_filter( 'rollbar_js_config', array($this, 'rollbar_js_config') );
  }

  function rollbar_js_config($config) {
    if(is_user_logged_in()) {
      $user = wp_get_current_user();  
      
      if(empty($config['payload']['person'])) {
        $config['payload']['person'] = array(
          'id' => $user->ID,
          'username' => $user->user_login,
          'email' => $user->user_email
        );
      }
    }

    return $config;
  }
}
```