### PR TITLE
Create WordPress Filter Hook to Override Plugin Settings

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -78,7 +78,7 @@ class Plugin {
                 Settings::DEFAULT_LOGGING_LEVEL
         );
         
-        $this->settings = $settings;
+        $this->settings = \apply_filters('rollbar_plugin_settings',$settings);
         
     }
     


### PR DESCRIPTION
In fetchSettings of Plugin, adding apply_filters to the $settings variable before function sets settings property so that WordPress developers can filter the Rollbar plugin settings with their code using a standard WordPress methodology.