### PR TITLE
GitHub Issue #36: Ability to append php logging config with filter

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,8 @@ if( !defined( 'ABSPATH' ) ) exit;
 
 class Plugin {
     
+    private $config;
+    
     private static $instance;
     
     private $settings = null;
@@ -16,6 +18,8 @@ class Plugin {
     private function __construct() {
         
         $this->fetchSettings();
+        
+        $this->config = array();
         
     }
     
@@ -32,6 +36,14 @@ class Plugin {
     
     public static function load() {
         return Plugin::instance();
+    }
+    
+    public function configure(array $config) {
+        $this->config = array_merge($this->config, $config);
+        
+        if ($logger = \Rollbar\Rollbar::logger()) {
+            $logger->configure($this->config);
+        }
     }
     
     private function initSettings() {

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -97,4 +97,39 @@ class PluginTest extends BaseTestCase {
         $this->assertEquals((E_ERROR | E_WARNING | E_PARSE | E_NOTICE), $result);
     }
     
+    public function testConfigure()
+    {
+        $expected = 'testConfigure';
+        
+        $plugin = \Rollbar\Wordpress\Plugin::instance();
+        
+        $plugin->setting('php_logging_enabled', 1);
+        $plugin->setting(
+            'logging_level',
+            \Rollbar\Wordpress\Plugin::buildIncludedErrno(E_WARNING)
+        );
+        $plugin->setting('server_side_access_token', $this->getAccessToken());
+        $plugin->setting('environment', $expected);
+        $plugin->configure(array('environment' => $expected));
+        
+        
+        $plugin->initPhpLogging();
+        
+        
+        $dataBuilder = \Rollbar\Rollbar::logger()->getDataBuilder();
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        
+        $this->assertEquals($expected, $output->getEnvironment());
+        
+        
+        $expected = "testConfigure2";
+        
+        $plugin->configure(array('environment' => $expected));
+        $dataBuilder = \Rollbar\Rollbar::logger()->getDataBuilder();
+        
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        
+        $this->assertEquals($expected, $output->getEnvironment());
+    }
+    
 }


### PR DESCRIPTION
Addresses issue https://github.com/rollbar/rollbar-php-wordpress/issues/36

Adds `\Rollbar\Wordpress\Plugin::configure` which allows for changing configuration options from an arbitrary place in the code, regardless of the state of loading up Wordpress.