### PR TITLE
Fix php 7.1 strict errors in wp-admin

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -312,6 +312,8 @@ class Settings
         $readme = file_get_contents(__DIR__ . '/../vendor/rollbar/rollbar/README.md');
         
         $option_pos = stripos($readme, '<dt>' . $option);
+
+        $desc = '';
         
         if ($option_pos !== false) {
         

--- a/src/UI.php
+++ b/src/UI.php
@@ -168,7 +168,7 @@ class UI
         <?php
     }
     
-    public function status($settings)
+    public static function status($settings)
     {
         extract($settings);
 
@@ -241,7 +241,7 @@ class UI
         return array();
     }
     
-    public function getIncludedErrnoDescriptions($value)
+    public static function getIncludedErrnoDescriptions($value)
     {
         switch ($value) {
             case E_ERROR:


### PR DESCRIPTION
Hi Artur,

Love all the new improvements! 
I tried the 2.3.0 release and my PHP 7.1 threw some exceptions on the admin page. I fixed them so hopefully this pull request is helpful.

Cheers,
Jan