### PR TITLE
Fix missing default method exception

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -388,6 +388,8 @@ class Plugin {
         if ($value === null) {
             try {
                 $value = $rollbarDefaults->$method();
+            } catch (\Throwable $e) {
+                $value = null;
             } catch (\Exception $e) {
                 $value = null;
             }


### PR DESCRIPTION
An undefined method is an Error not an Exception, so the block to catch an Exception is not executed when a method is not found. Add a block for Throwable which will catch Error and Exception in newer PHP versions, in PHP 5 the exception block will still be used.

Fixes #69 