### PR TITLE
Calls enableMustUsePlugin as an instance method

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -204,7 +204,7 @@ class Settings
             'rollbar_wp_advanced',
             array(
                 'type' => UI::getSettingType('enable_must_use_plugin'),
-                'default' => \Rollbar\Wordpress\Defaults::enableMustUsePlugin(),
+                'default' => \Rollbar\Wordpress\Defaults::instance()->enableMustUsePlugin(),
                 'description' => __('Allows Rollbar plugin to be loaded as early ' .
                                     'as possible as a Must-Use plugin. Activating / ' .
                                     'deactivating the plugin in the plugins admin panel ' .


### PR DESCRIPTION
Currently, the default value for the  `enable_must_use_plugin` setting is obtained as 

```php
'default'      => \Rollbar\Wordpress\Defaults::enableMustUsePlugin(),
```
 
https://github.com/rollbar/rollbar-php-wordpress/blob/d85766b6e7db644bb1de9ae6a96245bde839151b/src/Settings.php#L206-L208

But `enableMustUsePlugin` is an instance method, as shown on:

https://github.com/rollbar/rollbar-php-wordpress/blob/d85766b6e7db644bb1de9ae6a96245bde839151b/src/Defaults.php#L39-L43

So it throws a deprecation warning:


```sh
PHP Deprecated:  Non-static method Rollbar\Wordpress\Defaults::enableMustUsePlugin() 
should not be called statically  in 
/var/www/blog.example.com/wp-content/plugins/rollbar/src/Settings.php on line 207
```

In this PR I'm fixing said warning by using:

```php
'default'      => \Rollbar\Wordpress\Defaults::instance()->enableMustUsePlugin(),
```

I hope it helps.