### PR TITLE
fix(initPhpLogging): Moving fetch settings to before settings check.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -265,12 +265,12 @@ class Plugin {
     
     public function initPhpLogging()
     {
+        $this->fetchSettings();
+
         // Return if logging is not enabled
         if ( $this->settings['php_logging_enabled'] === 0 ) {
             return;
         }
-        
-        $this->fetchSettings();
         
         // installs global error and exception handlers
         try {


### PR DESCRIPTION
There is the bug that you cannot disable PhpLogging since the settings
property is not set until fetchSettings() is called. So I reordered.