### PR TITLE
don’t start a session for wp-cron

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -99,7 +99,7 @@ class Settings
     
     public static function registerSession()
     {
-        if( !session_id() && !defined( 'DOING_CRON' )) {
+        if( ! session_id() && ! defined( 'DOING_CRON' ) ) {
             session_start();
         }
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -99,7 +99,7 @@ class Settings
     
     public static function registerSession()
     {
-        if( !session_id() ) {
+        if( !session_id() && !defined( 'DOING_CRON' )) {
             session_start();
         }
     }


### PR DESCRIPTION
Possible fix for #85 and #86
Fixes #82