### PR TITLE
Check that settings aren't closures before sending them through `eval()`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -318,8 +318,8 @@ class Plugin {
         $config['timeout'] = intval($this->settings['timeout']);
         
         foreach (UI::settingsOfType(UI::SETTING_INPUT_TYPE_PHP) as $setting) {
-            
-            if (isset($config[$setting])) {
+
+            if (isset($config[$setting]) && ! ($config[$setting] instanceof \Closure)) {
                 
                 $code = is_string($config[$setting]) ?: 'return ' . var_export($config[$setting], true) . ';';
                 


### PR DESCRIPTION
This resolves #89