### PR TITLE
fix: correct PHP notice on register-rest-route in WordPress v5.5.0

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -164,6 +164,7 @@ class Plugin {
                 array(
                     'methods' => 'POST',
                     'callback' => '\Rollbar\Wordpress\Plugin::testPhpLogging',
+                    'permission_callback' => '__return_true',
                     'args' => array(
                         'server_side_access_token' => array(
                             'required' => true


### PR DESCRIPTION
As of WordPress 5.5.0 the `permission_callback` is required, or you get this:

Notice: register_rest_route was called <strong>incorrectly</strong>. The REST API route definition for <code>rollbar/v1/test-php-logging</code> is missing the required <code>permission_callback</code> argument. For REST API routes that are intended to be public, use <code>__return_true</code> as the permission callback. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.5.0.) 

This fixes that.