### PR TITLE
Also use the WP_ENV constant

### DIFF
--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -19,7 +19,7 @@ class Defaults {
     
     public function environment()
     {
-        return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
+        return \Rollbar\Wordpress\Plugin::getEnvironment();
     }
     
     public function root()

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -19,7 +19,7 @@ class Defaults {
     
     public function environment()
     {
-        return getenv('WP_ENV') ?: null;
+        return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
     }
     
     public function root()

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -53,7 +53,7 @@ class Plugin {
         Settings::init();
     }
 
-    private function getEnv()
+    private function getEnvironment()
     {
         return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
     }
@@ -73,7 +73,7 @@ class Plugin {
         
         if (!isset($options['environment']) || empty($options['environment'])) {
             
-            if ($wpEnv = $this->getEnv()) {
+            if ($wpEnv = $this->getEnvironment()) {
                 $options['environment'] = $wpEnv;
             }
             

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,6 +52,11 @@ class Plugin {
     private function initSettings() {
         Settings::init();
     }
+
+    private function getEnv()
+    {
+        return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
+    }
     
     /**
      * Fetch settings provided in Admin -> Tools -> Rollbar
@@ -68,7 +73,7 @@ class Plugin {
         
         if (!isset($options['environment']) || empty($options['environment'])) {
             
-            if ($wpEnv = getenv('WP_ENV')) {
+            if ($wpEnv = $this->getEnv()) {
                 $options['environment'] = $wpEnv;
             }
             

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -53,7 +53,7 @@ class Plugin {
         Settings::init();
     }
 
-    private function getEnvironment()
+    public static function getEnvironment()
     {
         return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
     }

--- a/src/UI.php
+++ b/src/UI.php
@@ -217,16 +217,13 @@ class UI
         </p>
         <?php
     }
-
-    public static function getEnvironment()
-    {
-        return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
-    }
     
     public static function environmentSettingNote()
     {
+        $env = \Rollbar\Wordpress\Plugin::getEnvironment();
+
         $output = 
-            '<p><code>WP_ENV</code> environment variable: <code> ' . self::getEnvironment() . ' </code></p>' .
+            '<p><code>WP_ENV</code> environment variable: <code>' . $env . '</code></p>' .
             '<p><small><strong>Rollbar for Wordpress honors the WP_ENV environment variable.</strong> ' .
             'If the <code>environment</code> setting is not specified here, it will take ' .
             'precendence over the default value.</strong></small></p>';

--- a/src/UI.php
+++ b/src/UI.php
@@ -217,11 +217,16 @@ class UI
         </p>
         <?php
     }
+
+    public static function getEnv()
+    {
+        return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
+    }
     
     public static function environmentSettingNote()
     {
         $output = 
-            '<p><code>WP_ENV</code> environment variable: <code> ' . getenv('WP_ENV') . ' </code></p>' .
+            '<p><code>WP_ENV</code> environment variable: <code> ' . self::getEnv() . ' </code></p>' .
             '<p><small><strong>Rollbar for Wordpress honors the WP_ENV environment variable.</strong> ' .
             'If the <code>environment</code> setting is not specified here, it will take ' .
             'precendence over the default value.</strong></small></p>';

--- a/src/UI.php
+++ b/src/UI.php
@@ -218,7 +218,7 @@ class UI
         <?php
     }
 
-    public static function getEnv()
+    public static function getEnvironment()
     {
         return ( getenv('WP_ENV') ?: ( defined( 'WP_ENV' ) ? WP_ENV : null ) );
     }
@@ -226,7 +226,7 @@ class UI
     public static function environmentSettingNote()
     {
         $output = 
-            '<p><code>WP_ENV</code> environment variable: <code> ' . self::getEnv() . ' </code></p>' .
+            '<p><code>WP_ENV</code> environment variable: <code> ' . self::getEnvironment() . ' </code></p>' .
             '<p><small><strong>Rollbar for Wordpress honors the WP_ENV environment variable.</strong> ' .
             'If the <code>environment</code> setting is not specified here, it will take ' .
             'precendence over the default value.</strong></small></p>';


### PR DESCRIPTION
Hiya. I'm a new customer. You've got a few PRs incoming based on my first impressions. If these are welcome I'd love to write more.

## Description of the change

In my experience WP_ENV is more often used as a constant than an environment variable. I don't want to get rid of the environment variable, but if it doesn't exist can we check the constant?

Fixes #68

## Type of change

- New feature (non-breaking change that adds functionality)

## Related issues

None.

## Checklists

I'm not yet familiar with testing, I did test manually of course, and I'm on Windows. I hope you'll take this without testing, or can run tests on my behalf.