### PR TITLE
Add settings link to plugins page

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -119,7 +119,7 @@ class Settings
 
     function addAdminMenuLink($links)
     {
-        $args['page'] = 'rollbar_wp';
+        $args = array('page' => 'rollbar_wp');
 
         $links['settings'] = '<a href="'.admin_url( 'options-general.php?'.http_build_query( $args ) ).'">'.__('Settings', 'rollbar').'</a>';
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -30,6 +30,7 @@ class Settings
     public static function init() {
         $instance = self::instance();
         \add_action('admin_menu', array(&$instance, 'addAdminMenu'));
+        \add_filter('plugin_action_links_'.basename(dirname(__DIR__)).'/rollbar-php-wordpress.php', array(&$instance, 'addAdminMenuLink'));
         \add_action('admin_init', array(&$instance, 'addSettings'));
         \add_action('admin_enqueue_scripts', function($hook) {
             
@@ -114,6 +115,15 @@ class Settings
             'rollbar_wp',
             array(&$this, 'optionsPage')
         );
+    }
+
+    function addAdminMenuLink($links)
+    {
+        $args['page'] = 'rollbar_wp';
+
+        $links['settings'] = '<a href="'.admin_url( 'options-general.php?'.http_build_query( $args ) ).'">'.__('Settings', 'rollbar').'</a>';
+
+        return $links;
     }
 
     function addSettings()


### PR DESCRIPTION
## Description of the change

Adds a link to the Rollbar settings page on the plugins page. This way, after activation, you won't have to browse all menus, you just click the settings link and find out.

![2022-06-05-04-45-18](https://user-images.githubusercontent.com/2203813/172033284-688e5b79-2b01-4cff-8691-20518e53a608.jpg)

## Type of change

- New feature (non-breaking change that adds functionality)

## Related issues

None.

## Checklists

I'm not yet familiar with testing, I did test manually of course, and I'm on Windows. I hope you'll take this without testing, or can run tests on my behalf.
