### PR TITLE
Display skipped test as success

### DIFF
--- a/public/js/RollbarWordpressSettings.js
+++ b/public/js/RollbarWordpressSettings.js
@@ -195,13 +195,13 @@
                 if (php_config.php_logging_enabled) {
                     logThroughPhp(php_config);
                 } else {
-                    failNotice("Skipped testing PHP logging since it is disabled.");
+                    successNotice("Skipped testing PHP logging since it is disabled.");
                 }
                 
                 if (js_logging_enabled) {
                     logThroughJs(client_side_access_token, environment, logging_level);
                 } else {
-                    failNotice("Skipped testing JS logging since it is disabled.");
+                    successNotice("Skipped testing JS logging since it is disabled.");
                 }
                 
             });


### PR DESCRIPTION
## Description of the change

If we choose not to test PHP/JS, and then run a test, it should not give feedback as an error. The skipping is good.

## Type of change

- Bug fix (non-breaking change that fixes an issue)

## Related issues

None.

## Checklists

I'm not yet familiar with testing, I did test manually of course, and I'm on Windows. I hope you'll take this without testing, or can run tests on my behalf.