### PR TITLE
Fixed new session on every request.

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -59,28 +59,6 @@ class Settings
                 Plugin::VERSION
             );
             
-            \wp_register_script( 
-                'AceEditor', 
-                \plugin_dir_url(__FILE__)."../public/js/ace-builds/src-min-noconflict/ace.js",
-                array('jquery'),
-                Plugin::VERSION
-            );
-            
-            \wp_localize_script(
-                'AceEditor', 
-                'AceEditorLocalized', 
-                array(
-                    'plugin_url' => \plugin_dir_url(__FILE__) . "../",
-                )
-            );
-            
-            \wp_enqueue_script(
-                "AceEditor",
-                \plugin_dir_url(__FILE__)."../public/js/ace-builds/src-min-noconflict/ace.js", 
-                array("jquery"),
-                Plugin::VERSION
-            );  
-            
             \wp_register_style(
                 'RollbarWordpressSettings',
                 \plugin_dir_url(__FILE__)."../public/css/RollbarWordpressSettings.css",

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -89,19 +89,10 @@ class Settings
             );
             \wp_enqueue_style('RollbarWordpressSettings');
         });
-        
-        \add_action('init', array(get_called_class(), 'registerSession'));
 
         \add_action('admin_post_rollbar_wp_restore_defaults', array(get_called_class(), 'restoreDefaultsAction'));
         
         \add_action('pre_update_option_rollbar_wp', array(get_called_class(), 'preUpdate'));
-    }
-    
-    public static function registerSession()
-    {
-        if( ! session_id() && ! defined( 'DOING_CRON' ) ) {
-            session_start();
-        }
     }
 
     function addAdminMenu()
@@ -372,6 +363,13 @@ class Settings
     
     public static function flashMessage($type, $message)
     {
+        // This is only designed to run in the admin for the main HTML request.
+        // If there is no session at this point something has gone terribly
+        // wrong, and we should bail out.
+        if( ! is_admin() || ! session_id() || wp_doing_cron() ) {
+            return;
+        }
+
         $_SESSION['rollbar_wp_flash_message'] = array(
             "type" => $type,
             "message" => $message
@@ -397,14 +395,18 @@ class Settings
             try {
                 Plugin::instance()->enableMustUsePlugin();
             } catch (\Exception $exception) {
-                self::flashMessage('error', 'Failed enabling the Must-Use plugin.');
+                add_action('admin_notices', function () {
+                    echo '<div class="error notice"><p><strong>Error:</strong> failed to enable the Rollbar Must-Use plugin.</p></div>';
+                });
                 $settings['enable_must_use_plugin'] = false;
             }
         } else {
             try {
                 Plugin::instance()->disableMustUsePlugin();
             } catch (\Exception $exception) {
-                self::flashMessage('error', 'Failed disabling the Must-Use plugin.');
+                add_action('admin_notices', function () {
+                    echo '<div class="error notice"><p><strong>Error:</strong> failed to disable the Rollbar Must-Use plugin.</p></div>';
+                });
                 $settings['enable_must_use_plugin'] = true;
             }
         }


### PR DESCRIPTION
## Description of the change

Removed the need for a new session to be created on every request. This is an antipattern and can cause issues. This was only used for "flash" messages. Most instances have been replaced with WP notices.

## Type of change

Bug fix (non-breaking change that fixes an issue)

## Related issues

Fix #85

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
