### PR TITLE
Cast "1" and "0" as booleans when they are expected as booleans.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -350,6 +350,13 @@ class Plugin {
             } else if (isset($config[$setting]) && $config[$setting] === 'true') {
                 $config[$setting] = true;
             }
+
+            // also handle 1 and 0 as booleans
+            else if (isset($config[$setting]) && $config[$setting] === '0') {
+                $config[$setting] = false;
+            } else if (isset($config[$setting]) && $config[$setting] === '1') {
+                $config[$setting] = true;
+            }
         }
         
         return $config;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -61,6 +61,22 @@ class PluginTest extends BaseTestCase {
         }
         
     }
+
+    /**
+     * Tests to ensure bools are properly converted from "1" and "0" strings
+     * 
+     * @ticket https://github.com/rollbar/rollbar-php-wordpress/issues/119
+     */
+    public function testSendMessageTraceBool(){
+        $plugin = $this->subject;
+
+        $plugin->setting( 'send_message_trace', '1' );
+        $plugin->setting( 'report_suppressed', '0' );
+        $data = $plugin->buildPHPConfig();
+
+        $this->assertTrue( $data['send_message_trace'] );
+        $this->assertFalse( $data['report_suppressed'] );
+    }
     
     public static function loggingLevelTestDataProvider()
     {


### PR DESCRIPTION
Rollbar/WordPress/UI creates checkboxes for booleans and stores the state as "1" and "0". The PHP8 version of https://github.com/rollbar/rollbar-php expects actual booleans. this updates the config builder to convert "1" and "0" into TRUE and FALSE.

Fixes: https://github.com/rollbar/rollbar-php-wordpress/issues/119

## Description of the change

Adds support to the boolean check in buildPHPConfig for "1" and "0".

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #119 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
